### PR TITLE
Add UNO R4 WiFi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ All text above must be included in any redistribution
 To install, use the Arduino Library Manager and search for "SCPI Red Pitaya" and install the library.
 
 ## WiFi helper
+Boards using the WiFiS3 library, such as the Arduino UNO R4 WiFi, are supported.
 You can now connect to a Red Pitaya over Wi‑Fi using `SCPIRPWiFi`. Provide your Wi‑Fi credentials and the Red Pitaya address:
 ```cpp
 #include <SCPI_RP_WiFi.h>
@@ -51,3 +52,6 @@ void setup() {
   Serial.println("Connected");
 }
 ```
+
+See the sketches in the examples/wifi directory for complete usage, including WiFi_analog_io.
+

--- a/examples/wifi/WiFi_analog_io/WiFi_analog_io.ino
+++ b/examples/wifi/WiFi_analog_io/WiFi_analog_io.ino
@@ -1,0 +1,57 @@
+// Example demonstrating analog input/output control over WiFi
+// using the SCPIRPWiFi helper. Connect AO0 to AI0 on the Red Pitaya
+// before running.
+//
+// REQUIRES the following Arduino libraries:
+// - SCPI Red Pitaya Library
+// - WiFiS3, WiFiNINA or WiFi
+
+#include <SCPI_RP_WiFi.h>
+
+const char ssid[] = "YOUR_WIFI";        // change me
+const char pass[] = "YOUR_PASS";        // change me
+const char host[] = "rp-f0ada4.local";  // or IP address
+const uint16_t port = 5000;
+
+scpi_rp::SCPIRPWiFi rp;
+
+bool isInit = false;
+float value = 0;
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+  if (!rp.begin(ssid, pass, host, port)) {
+    Serial.println("Connection failed");
+    while (true) {
+      delay(1000);
+    }
+  }
+  Serial.println("Connected to SCPI server");
+  isInit = true;
+}
+
+void loop() {
+  if (!isInit) {
+    return;
+  }
+  float in_value = 0;
+  if ((value * 10) > 18) value = 0;
+  if (!rp.aio.state(scpi_rp::AOUT_0, value)) {
+    Serial.println("Error set value");
+  }
+  if (!rp.aio.stateQ(scpi_rp::AOUT_0, &in_value)) {
+    Serial.println("Error get value");
+  }
+  Serial.print("AOUT_0 value = ");
+  Serial.println(in_value);
+  if (!rp.aio.stateQ(scpi_rp::AIN_0, &in_value)) {
+    Serial.println("Error get value");
+  }
+  Serial.print("AIN_0 value = ");
+  Serial.println(in_value);
+  delay(1000);
+  value += 0.1;
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -13,6 +13,7 @@ ESYSLog	KEYWORD1
 SCPISystem	KEYWORD1
 Value KEYWORD1
 BaseIO KEYWORD1
+SCPIRPWiFi    KEYWORD1
 
 ###########################################
 # Methods and Functions (KEYWORD2)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SCPI Red Pitaya
-version=1.0.0
+version=1.1.0
 author=Red Pitaya <info@redpitaya.com>
 maintainer=Red Piataya <info@redpitaya.com>
 sentence=Arduino library for Red Pitaya SCPI server

--- a/src/wifi/SCPI_RP_WiFi.cpp
+++ b/src/wifi/SCPI_RP_WiFi.cpp
@@ -1,0 +1,28 @@
+#include "wifi/SCPI_RP_WiFi.h"
+
+#include <Arduino.h>
+
+using namespace scpi_rp;
+
+bool SCPIRPWiFi::begin(const char* ssid, const char* pass, const char* host,
+                       uint16_t port) {
+  WiFi.begin(ssid, pass);
+  unsigned long t = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - t < 10000) {
+    delay(500);
+  }
+  if (WiFi.status() != WL_CONNECTED) {
+    return false;
+  }
+
+  IPAddress addr;
+  if (WiFi.hostByName(host, addr) != 1) {
+    return false;
+  }
+
+  if (!m_client.connect(addr, port)) {
+    return false;
+  }
+  initStream(&m_client);
+  return true;
+}

--- a/src/wifi/SCPI_RP_WiFi.h
+++ b/src/wifi/SCPI_RP_WiFi.h
@@ -1,0 +1,31 @@
+#ifndef SCPI_RP_WIFI_H
+#define SCPI_RP_WIFI_H
+
+#include "SCPI_RP.h"
+
+#if __has_include(<WiFiS3.h>)
+#include <WiFiS3.h>
+#elif __has_include(<WiFiNINA.h>)
+#include <WiFiNINA.h>
+#elif __has_include(<WiFi.h>)
+#include <WiFi.h>
+#else
+#error "No compatible WiFi library found"
+#endif
+
+namespace scpi_rp {
+
+class SCPIRPWiFi : public SCPIRedPitaya {
+ public:
+  SCPIRPWiFi() = default;
+
+  bool begin(const char* ssid, const char* pass, const char* host,
+             uint16_t port);
+
+ private:
+  WiFiClient m_client;
+};
+
+}  // namespace scpi_rp
+
+#endif


### PR DESCRIPTION
## Summary
- restore WiFi helper for connecting to Red Pitaya devices via WiFi
- mention WiFiS3/Arduino UNO R4 WiFi support in the README
- add WiFi analog I/O example sketch
- bump library version

## Testing
- `clang-format -n src/wifi/SCPI_RP_WiFi.h src/wifi/SCPI_RP_WiFi.cpp examples/wifi/WiFi_analog_io/WiFi_analog_io.ino`


------
https://chatgpt.com/codex/tasks/task_e_688c356c6e048325abe200b872990f81