### PR TITLE
Add SocketInterface for network SCPI streams

### DIFF
--- a/examples/ethernet/Ethernet_acquire_trigger_now/Ethernet_acquire_trigger_now.ino
+++ b/examples/ethernet/Ethernet_acquire_trigger_now/Ethernet_acquire_trigger_now.ino
@@ -148,7 +148,7 @@ void setup() {
   // if you get a connection, report back via serial:
   if (client.connect(server, 5000)) {
     Serial.println("connected");
-    rp.initStream(&client);
+    rp.initSocket(&client);
     acquire();
     client.stop();
   } else {

--- a/examples/ethernet/Ethernet_analog_io/Ethernet_analog_io.ino
+++ b/examples/ethernet/Ethernet_analog_io/Ethernet_analog_io.ino
@@ -59,7 +59,7 @@ void setup() {
   // if you get a connection, report back via serial:
   if (client.connect(server, 5000)) {
     Serial.println("connected");
-    rp.initStream(&client);
+    rp.initSocket(&client);
     isInit = true;
   } else {
     // if you didn't get a connection to the server:

--- a/examples/wifi/Wifi_acquire_trigger_now/Wifi_acquire_trigger_now.ino
+++ b/examples/wifi/Wifi_acquire_trigger_now/Wifi_acquire_trigger_now.ino
@@ -1,0 +1,153 @@
+#include <WiFiS3.h>
+
+#include "SCPI_RP.h"
+#include "arduino_secrets.h"  // defines SECRET_SSID & SECRET_PASS
+
+scpi_rp::SCPIRedPitaya rp;
+WiFiClient client;
+IPAddress server(192, 168, 0, 17);
+const uint16_t serverPort = 5000;
+
+void acquire();
+
+void setup() {
+  Serial.begin(115200);
+  delay(100);
+
+  // ————— STATIC IP (or DHCP if it fails silently) —————
+  {
+    IPAddress local(192, 168, 0, 50);
+    IPAddress gateway(192, 168, 0, 1);
+    IPAddress subnet(255, 255, 255, 0);
+    IPAddress dns(8, 8, 8, 8);
+    WiFi.config(local, gateway, subnet, dns);
+    Serial.println("⚙️  Static IP configuration applied (no return code)");
+  }
+
+  // ————— CONNECT TO WIFI —————
+  Serial.print("Connecting to WiFi \"");
+  Serial.print(SECRET_SSID);
+  Serial.println("\" ...");
+  WiFi.begin(SECRET_SSID, SECRET_PASS);
+
+  Serial.print("Waiting for connection");
+  unsigned long wifiStart = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - wifiStart < 30000) {
+    Serial.print(".");
+    delay(500);
+  }
+  Serial.println();
+
+  if (WiFi.status() != WL_CONNECTED) {
+    Serial.println("❌ WiFi connection failed");
+    while (true) delay(1000);
+  }
+  Serial.print("✅ WiFi connected — IP = ");
+  Serial.println(WiFi.localIP());
+
+  // ————— CONNECT TCP TO RED PITAYA —————
+  Serial.print("Connecting to Red Pitaya at ");
+  Serial.print(server);
+  Serial.print(":");
+  Serial.println(serverPort);
+
+  if (!client.connect(server, serverPort)) {
+    Serial.println("❌ TCP connection failed");
+    while (true) delay(1000);
+  }
+  Serial.println("✅ TCP connected!");
+
+  rp.initSocket(&client);
+  acquire();
+  client.stop();
+}
+
+void loop() { delay(1000); }
+
+void acquire() {
+  rp.gen.reset();
+  rp.gen.wave(scpi_rp::GEN_CH_1, scpi_rp::SINE);
+  rp.gen.freq(scpi_rp::GEN_CH_1, 10000);
+  rp.gen.amp(scpi_rp::GEN_CH_1, 0.9);
+  rp.gen.enable(scpi_rp::GEN_CH_1, true);
+  rp.gen.sync(scpi_rp::GEN_CH_1);
+
+  if (!rp.acq.control.reset()) {
+    Serial.println("Error reset acq");
+  }
+
+  float hysteresis = 0.05;
+  if (!rp.acq.trigger.hysteresis(hysteresis)) {
+    Serial.println("Error set hysteresis");
+  }
+
+  if (!rp.acq.trigger.hysteresisQ(&hysteresis)) {
+    Serial.println("Error get hysteresis");
+  } else {
+    Serial.print("Hysteresis = ");
+    Serial.println(hysteresis);
+  }
+
+  uint32_t decimation = 123;
+  if (!rp.acq.settings.decimationFactor(decimation)) {
+    Serial.println("Error set decimation");
+  }
+
+  if (!rp.acq.settings.decimationFactorQ(&decimation)) {
+    Serial.println("Error get decimation");
+  } else {
+    Serial.print("Decimation = ");
+    Serial.println(decimation);
+  }
+
+  if (!rp.acq.control.start()) {
+    Serial.println("Error start ADC");
+  }
+
+  if (!rp.acq.trigger.trigger(scpi_rp::ACQ_CH1_PE)) {
+    Serial.println("Error set trigger");
+  }
+
+  while (1) {
+    bool state = false;
+    rp.acq.trigger.stateQ(&state);
+    if (state) break;
+  }
+
+  while (1) {
+    bool state = false;
+    rp.acq.trigger.fillQ(&state);
+    if (state) break;
+  }
+
+  if (!rp.acq.control.stop()) {
+    Serial.println("Error stop ADC");
+  }
+
+  uint32_t wp = 0;
+  if (!rp.acq.data.writePositionQ(&wp)) {
+    Serial.println("Error get write pointer");
+  } else {
+    Serial.print("Write pointer = ");
+    Serial.println(wp);
+  }
+
+  uint32_t tp = 0;
+  if (!rp.acq.data.triggerPositionQ(&tp)) {
+    Serial.println("Error get trigger pointer");
+  } else {
+    Serial.print("Trigger pointer = ");
+    Serial.println(tp);
+  }
+
+  bool last = false;
+  float sample = 0;
+  int idx = 0;
+  while (!last) {
+    rp.acq.data.dataStartEndQ(scpi_rp::ACQ_CH_1, tp, wp, &sample, &last);
+    Serial.print(idx++);
+    Serial.print(" - ");
+    Serial.print(sample, 6);
+    Serial.println("");
+  }
+}

--- a/examples/wifi/Wifi_analog_io/Wifi_analog_io.ino
+++ b/examples/wifi/Wifi_analog_io/Wifi_analog_io.ino
@@ -3,16 +3,13 @@
 #include "SCPI_RP.h"
 #include "arduino_secrets.h"  // defines SECRET_SSID & SECRET_PASS
 
-// Forward‐declare your full acquisition routine
-void acquire();
-
-// SCPI + WiFi client objects
 scpi_rp::SCPIRedPitaya rp;
 WiFiClient client;
-uint8_t led_state = 1;
-// Red Pitaya’s IP & port (update as needed)
 IPAddress server(192, 168, 0, 17);
 const uint16_t serverPort = 5000;
+
+bool isInit = false;
+float value = 0;
 
 void setup() {
   Serial.begin(115200);
@@ -61,24 +58,28 @@ void setup() {
   }
   Serial.println("✅ TCP connected!");
 
-  // ————— RUN YOUR SCPI STREAM + ACQUIRE —————
   rp.initSocket(&client);
-  acquire();
-
-  client.stop();
-  Serial.println("All done.");
+  isInit = true;
 }
 
 void loop() {
-  // nothing left to do
-  delay(1000);
-}
-
-// ————— Original acquisition routine, verbatim —————
-void acquire() {
-  rp.dio.state((scpi_rp::EDIOPin)(led_state), 1);
-  delay(1000);
-  rp.dio.state((scpi_rp::EDIOPin)(led_state), 0);
-  led_state++;
-  if (led_state == 8) led_state = 0;
+  if (isInit) {
+    float in_value = 0;
+    if ((value * 10) > 18) value = 0;
+    if (!rp.aio.state(scpi_rp::AOUT_0, value)) {
+      Serial.println("Error set value");
+    }
+    if (!rp.aio.stateQ(scpi_rp::AOUT_0, &in_value)) {
+      Serial.println("Error get value");
+    }
+    Serial.print("AOUT_0 value = ");
+    Serial.println(in_value);
+    if (!rp.aio.stateQ(scpi_rp::AIN_0, &in_value)) {
+      Serial.println("Error get value");
+    }
+    Serial.print("AIN_0 value = ");
+    Serial.println(in_value);
+    delay(1000);
+    value += 0.1;
+  }
 }

--- a/keywords.txt
+++ b/keywords.txt
@@ -20,3 +20,4 @@ BaseIO KEYWORD1
 
 initStream	KEYWORD2
 
+initSocket      KEYWORD2

--- a/src/SCPI_RP.cpp
+++ b/src/SCPI_RP.cpp
@@ -12,6 +12,7 @@
 #include "SCPI_RP.h"
 
 #include "common/base_io.h"
+#include "socket/socket_scpi.h"
 #include "uart/uart_scpi.h"
 
 using namespace scpi_rp;
@@ -39,4 +40,23 @@ void SCPIRedPitaya::initStream(Stream *serial) {
   acq.trigger.setInterface(u);
   acq.dma.settings.setInterface(u);
   acq.dma.data.setInterface(u);
+}
+
+void SCPIRedPitaya::initSocket(Stream *serial) {
+  SocketInterface *s = new SocketInterface();
+  s->init(serial);
+  g_base_io = s;
+  system.setInterface(s);
+  dio.setInterface(s);
+  aio.setInterface(s);
+  daisy.setInterface(s);
+  pll.setInterface(s);
+  system_led.setInterface(s);
+  gen.setInterface(s);
+  acq.control.setInterface(s);
+  acq.settings.setInterface(s);
+  acq.data.setInterface(s);
+  acq.trigger.setInterface(s);
+  acq.dma.settings.setInterface(s);
+  acq.dma.data.setInterface(s);
 }

--- a/src/SCPI_RP.h
+++ b/src/SCPI_RP.h
@@ -40,6 +40,13 @@ class SCPIRedPitaya {
    */
   void initStream(Stream *serial);
 
+  /*!
+   * Initialize SCPI communication over a network socket.
+   *
+   * @param serial Stream representing the socket connection.
+   */
+  void initSocket(Stream *serial);
+
   SCPIAio aio;
   SCPIDaisy daisy;
   SCPIDio dio;

--- a/src/socket/socket_scpi.cpp
+++ b/src/socket/socket_scpi.cpp
@@ -1,0 +1,31 @@
+#include "socket_scpi.h"
+
+using namespace scpi_rp;
+
+SocketInterface::SocketInterface() : m_stream(nullptr) {}
+
+SocketInterface::~SocketInterface() {}
+
+int SocketInterface::init(Stream *stream) {
+  m_stream = stream;
+  return 0;
+}
+
+scpi_size SocketInterface::write(const uint8_t *_data, scpi_size _size) {
+  scpi_size sent = 0;
+  while (sent < _size) {
+    sent += m_stream->write(_data + sent, _size - sent);
+  }
+  return sent;
+}
+
+scpi_size SocketInterface::readToBuffer() {
+  scpi_size rs = 0;
+  while (m_stream->available() && m_bufferSize < BASE_IO_BUFFER_SIZE) {
+    int c = m_stream->read();
+    if (c < 0) break;
+    m_buffer[m_bufferSize++] = static_cast<uint8_t>(c);
+    rs++;
+  }
+  return rs;
+}

--- a/src/socket/socket_scpi.h
+++ b/src/socket/socket_scpi.h
@@ -1,0 +1,28 @@
+#ifndef SOCKET_SCPI_H
+#define SOCKET_SCPI_H
+
+#include <Stream.h>
+#include <stdint.h>
+
+#include "common/base_io.h"
+
+namespace scpi_rp {
+
+class SocketInterface : public BaseIO {
+ public:
+  SocketInterface();
+  ~SocketInterface();
+
+  int init(Stream *stream);
+
+  scpi_size write(const uint8_t *_data, scpi_size _size) override;
+
+ private:
+  scpi_size readToBuffer() override;
+
+  Stream *m_stream;
+};
+
+}  // namespace scpi_rp
+
+#endif


### PR DESCRIPTION
## Summary
- implement `SocketInterface` BaseIO subclass
- expose `initSocket` helper on `SCPIRedPitaya`
- use `initSocket` in WiFi/Ethernet examples
- document keyword for `initSocket`

## Testing
- `clang-format -i src/socket/socket_scpi.h src/socket/socket_scpi.cpp src/SCPI_RP.h src/SCPI_RP.cpp examples/WifiLEDs.ino examples/wifi/Wifi_analog_io/Wifi_analog_io.ino examples/wifi/Wifi_acquire_trigger_now/Wifi_acquire_trigger_now.ino examples/ethernet/Ethernet_acquire_trigger_now/Ethernet_acquire_trigger_now.ino examples/ethernet/Ethernet_analog_io/Ethernet_analog_io.ino keywords.txt`
- `clang-format --version`


------
https://chatgpt.com/codex/tasks/task_e_688c5a6091848325a343e38abad76824