### PR TITLE
Fix decimation calls

### DIFF
--- a/examples/ethernet/Ethernet_acquire_trigger_now/Ethernet_acquire_trigger_now.ino
+++ b/examples/ethernet/Ethernet_acquire_trigger_now/Ethernet_acquire_trigger_now.ino
@@ -53,16 +53,16 @@ void acquire() {
     Serial.println(hysteresis);
   }
 
-  uint32_t decimation = 123;
-  if (!rp.acq.settings.decimationFactor(decimation)) {
+  scpi_rp::EACQDecimation decimation = scpi_rp::ACQ_DEC_1;
+  if (!rp.acq.settings.decimation(decimation)) {
     Serial.println("Error set decimation");
   }
 
-  if (!rp.acq.settings.decimationFactorQ(&decimation)) {
+  if (!rp.acq.settings.decimationQ(&decimation)) {
     Serial.println("Error get decimation");
   } else {
     Serial.print("Decimation = ");
-    Serial.println(decimation);
+    Serial.println((uint32_t)decimation);
   }
 
   if (!rp.acq.control.start()) {

--- a/examples/fast_adc/acquire_external_trigger/acquire_external_trigger.ino
+++ b/examples/fast_adc/acquire_external_trigger/acquire_external_trigger.ino
@@ -42,16 +42,16 @@ void setup() {
     Serial.println("Error reset acq");
   }
 
-  uint32_t decimation = 128;
-  if (!rp.acq.settings.decimationFactor(decimation)) {
+  scpi_rp::EACQDecimation decimation = scpi_rp::ACQ_DEC_1;
+  if (!rp.acq.settings.decimation(decimation)) {
     Serial.println("Error set decimation");
   }
 
-  if (!rp.acq.settings.decimationFactorQ(&decimation)) {
+  if (!rp.acq.settings.decimationQ(&decimation)) {
     Serial.println("Error get decimation");
   } else {
     Serial.print("Decimation = ");
-    Serial.println(decimation);
+    Serial.println((uint32_t)decimation);
   }
 
   if (!rp.acq.control.start()) {

--- a/examples/fast_adc/acquire_trigger_now/acquire_trigger_now.ino
+++ b/examples/fast_adc/acquire_trigger_now/acquire_trigger_now.ino
@@ -54,16 +54,16 @@ void setup() {
     Serial.println(hysteresis);
   }
 
-  uint32_t decimation = 123;
-  if (!rp.acq.settings.decimationFactor(decimation)) {
+  scpi_rp::EACQDecimation decimation = scpi_rp::ACQ_DEC_1;
+  if (!rp.acq.settings.decimation(decimation)) {
     Serial.println("Error set decimation");
   }
 
-  if (!rp.acq.settings.decimationFactorQ(&decimation)) {
+  if (!rp.acq.settings.decimationQ(&decimation)) {
     Serial.println("Error get decimation");
   } else {
     Serial.print("Decimation = ");
-    Serial.println(decimation);
+    Serial.println((uint32_t)decimation);
   }
 
   if (!rp.acq.control.start()) {

--- a/examples/wifi/Wifi_acquire_trigger_now/Wifi_acquire_trigger_now.ino
+++ b/examples/wifi/Wifi_acquire_trigger_now/Wifi_acquire_trigger_now.ino
@@ -88,16 +88,16 @@ void acquire() {
     Serial.println(hysteresis);
   }
 
-  uint32_t decimation = 123;
-  if (!rp.acq.settings.decimationFactor(decimation)) {
+  scpi_rp::EACQDecimation decimation = scpi_rp::ACQ_DEC_1;
+  if (!rp.acq.settings.decimation(decimation)) {
     Serial.println("Error set decimation");
   }
 
-  if (!rp.acq.settings.decimationFactorQ(&decimation)) {
+  if (!rp.acq.settings.decimationQ(&decimation)) {
     Serial.println("Error get decimation");
   } else {
     Serial.print("Decimation = ");
-    Serial.println(decimation);
+    Serial.println((uint32_t)decimation);
   }
 
   if (!rp.acq.control.start()) {


### PR DESCRIPTION
## Summary
- use `decimation()`/`decimationQ()` with supported enums

## Testing
- `clang-format -n examples/wifi/Wifi_acquire_trigger_now/Wifi_acquire_trigger_now.ino examples/ethernet/Ethernet_acquire_trigger_now/Ethernet_acquire_trigger_now.ino examples/fast_adc/acquire_trigger_now/acquire_trigger_now.ino examples/fast_adc/acquire_external_trigger/acquire_external_trigger.ino`


------
https://chatgpt.com/codex/tasks/task_e_688c65bce3e483259a70ea723a1436dd