### PR TITLE
Use WiFiClient in fast_dac examples

### DIFF
--- a/examples/fast_dac/arb_signal/arb_signal.ino
+++ b/examples/fast_dac/arb_signal/arb_signal.ino
@@ -7,29 +7,33 @@
 // https://github.com/RedPitaya/SCPI-red-pitaya-arduino
 
 #include <Arduino.h>
+#include <WiFi.h>
 
 #include "SCPI_RP.h"
 
-#if defined(ARDUINO_ARCH_AVR)
-#include <SoftwareSerial.h>
-SoftwareSerial uart(8, 9);  // Initializes line 8 as RX and line 9 as TX for
-                            // SCPI communication via UART
-#endif
+const char *SSID = "YOUR_SSID";
+const char *PASSWORD = "YOUR_PASSWORD";
+IPAddress server(192, 168, 0, 17);
+const uint16_t serverPort = 5000;
 
 scpi_rp::SCPIRedPitaya rp;
+WiFiClient client;
 
 void setup() {
   // Initializing console output
   Serial.begin(115200);
+  WiFi.begin(SSID, PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
 
-#if defined(ARDUINO_ARCH_AVR)
-  uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
-#elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
-    defined(ARDUINO_ARCH_SAM)
-  Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
-#endif
+  if (!client.connect(server, serverPort)) {
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  rp.initSocket(&client);
   rp.gen.reset();
   rp.gen.wave(scpi_rp::GEN_CH_1, scpi_rp::ARBITRARY);
   rp.gen.freq(scpi_rp::GEN_CH_1, 10000);

--- a/examples/fast_dac/burst_switching_wave/burst_switching_wave.ino
+++ b/examples/fast_dac/burst_switching_wave/burst_switching_wave.ino
@@ -7,30 +7,34 @@
 // https://github.com/RedPitaya/SCPI-red-pitaya-arduino
 
 #include <Arduino.h>
+#include <WiFi.h>
 
 #include "SCPI_RP.h"
 
-#if defined(ARDUINO_ARCH_AVR)
-#include <SoftwareSerial.h>
-SoftwareSerial uart(8, 9);  // Initializes line 8 as RX and line 9 as TX for
-                            // SCPI communication via UART
-#endif
+const char *SSID = "YOUR_SSID";
+const char *PASSWORD = "YOUR_PASSWORD";
+IPAddress server(192, 168, 0, 17);
+const uint16_t serverPort = 5000;
 
 scpi_rp::SCPIRedPitaya rp;
+WiFiClient client;
 uint8_t waveform = 0;
 
 void setup() {
   // Initializing console output
   Serial.begin(115200);
+  WiFi.begin(SSID, PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
 
-#if defined(ARDUINO_ARCH_AVR)
-  uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
-#elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
-    defined(ARDUINO_ARCH_SAM)
-  Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
-#endif
+  if (!client.connect(server, serverPort)) {
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  rp.initSocket(&client);
 
   scpi_rp::EGENTrigger trig = scpi_rp::GEN_INT;
 

--- a/examples/fast_dac/burst_with_ext_trigger/burst_with_ext_trigger.ino
+++ b/examples/fast_dac/burst_with_ext_trigger/burst_with_ext_trigger.ino
@@ -8,29 +8,33 @@
 // https://github.com/RedPitaya/SCPI-red-pitaya-arduino
 
 #include <Arduino.h>
+#include <WiFi.h>
 
 #include "SCPI_RP.h"
 
-#if defined(ARDUINO_ARCH_AVR)
-#include <SoftwareSerial.h>
-SoftwareSerial uart(8, 9);  // Initializes line 8 as RX and line 9 as TX for
-                            // SCPI communication via UART
-#endif
+const char *SSID = "YOUR_SSID";
+const char *PASSWORD = "YOUR_PASSWORD";
+IPAddress server(192, 168, 0, 17);
+const uint16_t serverPort = 5000;
 
 scpi_rp::SCPIRedPitaya rp;
+WiFiClient client;
 
 void setup() {
   // Initializing console output
   Serial.begin(115200);
+  WiFi.begin(SSID, PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
 
-#if defined(ARDUINO_ARCH_AVR)
-  uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
-#elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
-    defined(ARDUINO_ARCH_SAM)
-  Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
-#endif
+  if (!client.connect(server, serverPort)) {
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  rp.initSocket(&client);
 
   rp.dio.reset();
   rp.dio.dir(scpi_rp::DIO_0_P, scpi_rp::IN);

--- a/examples/fast_dac/frequency_switching/frequency_switching.ino
+++ b/examples/fast_dac/frequency_switching/frequency_switching.ino
@@ -8,31 +8,35 @@
 // https://github.com/RedPitaya/SCPI-red-pitaya-arduino
 
 #include <Arduino.h>
+#include <WiFi.h>
 
 #include "SCPI_RP.h"
 
-#if defined(ARDUINO_ARCH_AVR)
-#include <SoftwareSerial.h>
-SoftwareSerial uart(8, 9);  // Initializes line 8 as RX and line 9 as TX for
-                            // SCPI communication via UART
-#endif
+const char *SSID = "YOUR_SSID";
+const char *PASSWORD = "YOUR_PASSWORD";
+IPAddress server(192, 168, 0, 17);
+const uint16_t serverPort = 5000;
 
 scpi_rp::SCPIRedPitaya rp;
+WiFiClient client;
 
 float freq = 10000;
 
 void setup() {
   // Initializing console output
   Serial.begin(115200);
+  WiFi.begin(SSID, PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
 
-#if defined(ARDUINO_ARCH_AVR)
-  uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
-#elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
-    defined(ARDUINO_ARCH_SAM)
-  Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
-#endif
+  if (!client.connect(server, serverPort)) {
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  rp.initSocket(&client);
 
   if (!rp.gen.reset()) {
     Serial.println("Error reset");

--- a/examples/fast_dac/pwm_duty_cycle_30/pwm_duty_cycle_30.ino
+++ b/examples/fast_dac/pwm_duty_cycle_30/pwm_duty_cycle_30.ino
@@ -7,26 +7,32 @@
 // https://github.com/RedPitaya/SCPI-red-pitaya-arduino
 
 #include <Arduino.h>
+#include <WiFi.h>
 
 #include "SCPI_RP.h"
 
-#if defined(ARDUINO_ARCH_AVR)
-#include <SoftwareSerial.h>
-SoftwareSerial uart(8, 9);  // Initializes line 8 as RX and line 9 as TX for
-                            // SCPI communication via UART
-#endif
+const char *SSID = "YOUR_SSID";
+const char *PASSWORD = "YOUR_PASSWORD";
+IPAddress server(192, 168, 0, 17);
+const uint16_t serverPort = 5000;
 
 scpi_rp::SCPIRedPitaya rp;
+WiFiClient client;
 
 void setup() {
-#if defined(ARDUINO_ARCH_AVR)
-  uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
-#elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
-    defined(ARDUINO_ARCH_SAM)
-  Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
-#endif
+  Serial.begin(115200);
+  WiFi.begin(SSID, PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+
+  if (!client.connect(server, serverPort)) {
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  rp.initSocket(&client);
   rp.gen.reset();
   rp.gen.wave(scpi_rp::GEN_CH_1, scpi_rp::PWM);
   rp.gen.dutyCycle(scpi_rp::GEN_CH_1, 0.3);

--- a/examples/fast_dac/sine_1ch_continue/sine_1ch_continue.ino
+++ b/examples/fast_dac/sine_1ch_continue/sine_1ch_continue.ino
@@ -7,26 +7,32 @@
 // https://github.com/RedPitaya/SCPI-red-pitaya-arduino
 
 #include <Arduino.h>
+#include <WiFi.h>
 
 #include "SCPI_RP.h"
 
-#if defined(ARDUINO_ARCH_AVR)
-#include <SoftwareSerial.h>
-SoftwareSerial uart(8, 9);  // Initializes line 8 as RX and line 9 as TX for
-                            // SCPI communication via UART
-#endif
+const char *SSID = "YOUR_SSID";
+const char *PASSWORD = "YOUR_PASSWORD";
+IPAddress server(192, 168, 0, 17);
+const uint16_t serverPort = 5000;
 
 scpi_rp::SCPIRedPitaya rp;
+WiFiClient client;
 
 void setup() {
-#if defined(ARDUINO_ARCH_AVR)
-  uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
-#elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
-    defined(ARDUINO_ARCH_SAM)
-  Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
-#endif
+  Serial.begin(115200);
+  WiFi.begin(SSID, PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+
+  if (!client.connect(server, serverPort)) {
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  rp.initSocket(&client);
   rp.gen.reset();
   rp.gen.wave(scpi_rp::GEN_CH_1, scpi_rp::SINE);
   rp.gen.freq(scpi_rp::GEN_CH_1, 10000);

--- a/examples/fast_dac/sine_1ch_sweep_mode/sine_1ch_sweep_mode.ino
+++ b/examples/fast_dac/sine_1ch_sweep_mode/sine_1ch_sweep_mode.ino
@@ -8,28 +8,32 @@
 // https://github.com/RedPitaya/SCPI-red-pitaya-arduino
 
 #include <Arduino.h>
+#include <WiFi.h>
 
 #include "SCPI_RP.h"
 
-#if defined(ARDUINO_ARCH_AVR)
-#include <SoftwareSerial.h>
-SoftwareSerial uart(8, 9);  // Initializes line 8 as RX and line 9 as TX for
-                            // SCPI communication via UART
-#endif
+const char *SSID = "YOUR_SSID";
+const char *PASSWORD = "YOUR_PASSWORD";
+IPAddress server(192, 168, 0, 17);
+const uint16_t serverPort = 5000;
 
 scpi_rp::SCPIRedPitaya rp;
+WiFiClient client;
 
 void setup() {
   Serial.begin(115200);
+  WiFi.begin(SSID, PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
 
-#if defined(ARDUINO_ARCH_AVR)
-  uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
-#elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
-    defined(ARDUINO_ARCH_SAM)
-  Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
-#endif
+  if (!client.connect(server, serverPort)) {
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  rp.initSocket(&client);
 
   scpi_rp::EGENSweepMode mode = scpi_rp::GEN_SWEEP_LINEAR;
   scpi_rp::EGENSweepDir dir = scpi_rp::GEN_SWEEP_NORMAL;

--- a/examples/fast_dac/sine_2ch_continue/sine_2ch_continue.ino
+++ b/examples/fast_dac/sine_2ch_continue/sine_2ch_continue.ino
@@ -7,29 +7,33 @@
 // https://github.com/RedPitaya/SCPI-red-pitaya-arduino
 
 #include <Arduino.h>
+#include <WiFi.h>
 
 #include "SCPI_RP.h"
 
-#if defined(ARDUINO_ARCH_AVR)
-#include <SoftwareSerial.h>
-SoftwareSerial uart(8, 9);  // Initializes line 8 as RX and line 9 as TX for
-                            // SCPI communication via UART
-#endif
+const char *SSID = "YOUR_SSID";
+const char *PASSWORD = "YOUR_PASSWORD";
+IPAddress server(192, 168, 0, 17);
+const uint16_t serverPort = 5000;
 
 scpi_rp::SCPIRedPitaya rp;
+WiFiClient client;
 
 void setup() {
   // Initializing console output
   Serial.begin(115200);
+  WiFi.begin(SSID, PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
 
-#if defined(ARDUINO_ARCH_AVR)
-  uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
-#elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
-    defined(ARDUINO_ARCH_SAM)
-  Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
-#endif
+  if (!client.connect(server, serverPort)) {
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  rp.initSocket(&client);
 
   if (!rp.gen.reset()) {
     Serial.println("Error reset");

--- a/examples/fast_dac/sine_2ch_continue_phase_shift/sine_2ch_continue_phase_shift.ino
+++ b/examples/fast_dac/sine_2ch_continue_phase_shift/sine_2ch_continue_phase_shift.ino
@@ -8,29 +8,33 @@
 // https://github.com/RedPitaya/SCPI-red-pitaya-arduino
 
 #include <Arduino.h>
+#include <WiFi.h>
 
 #include "SCPI_RP.h"
 
-#if defined(ARDUINO_ARCH_AVR)
-#include <SoftwareSerial.h>
-SoftwareSerial uart(8, 9);  // Initializes line 8 as RX and line 9 as TX for
-                            // SCPI communication via UART
-#endif
+const char *SSID = "YOUR_SSID";
+const char *PASSWORD = "YOUR_PASSWORD";
+IPAddress server(192, 168, 0, 17);
+const uint16_t serverPort = 5000;
 
 scpi_rp::SCPIRedPitaya rp;
+WiFiClient client;
 
 void setup() {
   // Initializing console output
   Serial.begin(115200);
+  WiFi.begin(SSID, PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
 
-#if defined(ARDUINO_ARCH_AVR)
-  uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
-#elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
-    defined(ARDUINO_ARCH_SAM)
-  Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
-#endif
+  if (!client.connect(server, serverPort)) {
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  rp.initSocket(&client);
 
   if (!rp.gen.reset()) {
     Serial.println("Error reset");


### PR DESCRIPTION
## Summary
- Replace SoftwareSerial/Serial1 in fast_dac sketches with WiFiClient
- Add WiFi connection setup and initialize SCPI over sockets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689935af69f4832595025a81d72babf5